### PR TITLE
:white_check_mark: add: tests without the methods to use cheerio

### DIFF
--- a/__tests__/mail-to-slack-msg.test.ts
+++ b/__tests__/mail-to-slack-msg.test.ts
@@ -18,9 +18,38 @@ test('if set the email list of "to", "getSenderAndReceiver" will return it.', ()
   expect(mailToSlackMsg.getSenderAndReceiver()).toBe('> to Taro Yamada tyamada@example.com / hanako@example.com');
 });
 
+test('if set the email list of "cc", "getSenderAndReceiver" will return it.', () => {
+  const mailToSlackMsg = new MailToSlackMsg({
+    cc: [{ name: 'Taro Yamada', address: 'tyamada@example.com' }, { address: 'hanako@example.com' }],
+  });
+
+  expect(mailToSlackMsg.getSenderAndReceiver()).toBe('> cc Taro Yamada tyamada@example.com / hanako@example.com');
+});
+
 test('if set the date, "whenThereIsDate" will return it.', () => {
   const date = new Date().toString();
   const mailToSlackMsg = new MailToSlackMsg({ date });
 
   expect(mailToSlackMsg.whenThereIsDate()).toBe(`:clock2: \`${date}\``);
+});
+
+test('if set the Subject, "whenThereIsSubject" will return it.', () => {
+  const subject = 'subject';
+  const mailToSlackMsg = new MailToSlackMsg({ subject });
+
+  expect(mailToSlackMsg.whenThereIsSubject()).toBe(`*${subject}*`);
+  expect(mailToSlackMsg.get()).toBe(`:email: *${subject}*`);
+});
+
+test('if set the Attachments, "whenThereIsAttachments" will return it.', () => {
+  const attachments = [{ fileName: 'hoge.txt' }, { fileName: 'fuga.jpg' }];
+  const mailToSlackMsg = new MailToSlackMsg({ attachments });
+
+  expect(mailToSlackMsg.whenThereIsAttachments()).toBe(':open_file_folder: `hoge.txt` `fuga.jpg`');
+});
+
+test('if did not set all parameters, "get" will return it.', () => {
+  const mailToSlackMsg = new MailToSlackMsg({});
+
+  expect(mailToSlackMsg.get()).toBe(':email: ');
 });

--- a/lib/mail-to-slack-msg.ts
+++ b/lib/mail-to-slack-msg.ts
@@ -183,12 +183,12 @@ export class MailToSlackMsg {
    * This method will return the email's contents.
    */
   public getBody(): string {
-    const bodyText = this.$('body').text();
+    const bodyText = this.$('body').text().trim();
 
     /**
      * The empty email's contents is empty but this may include enter-code when some time.
      */
-    if (bodyText === '\n') {
+    if (bodyText === '') {
       return '';
     }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run lint",
+      "pre-commit": "yarn run lint && yarn run test",
       "pre-push": "#"
     }
   },


### PR DESCRIPTION
I added the test codes.
+ if set the email list of "cc"
+ if set the Subject
+ if set the Attachments
+ if did not set all parameters